### PR TITLE
Fix owner for directory /opt/hivemq/backup

### DIFF
--- a/hivemq4/base-image/docker-entrypoint.sh
+++ b/hivemq4/base-image/docker-entrypoint.sh
@@ -26,6 +26,7 @@ if [[ "$(id -u)" = "0" ]]; then
     chown "${uid}":"${gid}" /opt/hivemq/conf
     chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
     chown "${uid}":"${gid}" /opt/hivemq/license
+    chown "${uid}":"${gid}" /opt/hivemq/backup
     # Recursive for bin, no volume here
     chown -R "${uid}":"${gid}" /opt/hivemq/bin
     chmod 700 /opt/hivemq


### PR DESCRIPTION
Owner of directory ```/opt/hivemq/backup``` was ```root:root```. This caused a triggered backup to fail with error message

> ERROR - Could not write retained messages into xml: Unable to create directory /opt/hivemq/backup/...

Fixed owner to ```hivemq:hivemq``` in ```docker-entrypoint.sh```. 