### PR TITLE
Added correct ownership for backup folder.

### DIFF
--- a/hivemq4/base-image/docker-entrypoint.sh
+++ b/hivemq4/base-image/docker-entrypoint.sh
@@ -26,6 +26,7 @@ if [[ "$(id -u)" = "0" ]]; then
     chown "${uid}":"${gid}" /opt/hivemq/conf
     chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
     chown "${uid}":"${gid}" /opt/hivemq/license
+    chown "${uid}":"${gid}" /opt/hivemq/backup
     # Recursive for bin, no volume here
     chown -R "${uid}":"${gid}" /opt/hivemq/bin
     chmod 700 /opt/hivemq


### PR DESCRIPTION
Needed for HiveMQ 4.2 backup feature.
Credit to Marius Hartfelder