### PR TITLE
improve error handling for the ownership adjustments

### DIFF
--- a/hivemq4/base-image/docker-entrypoint.sh
+++ b/hivemq4/base-image/docker-entrypoint.sh
@@ -37,9 +37,12 @@ readonly exec_cmd
 
 if [[ "$(id -u)" = "0" ]]; then
     # Restrict HiveMQ folder permissions, non-recursive so we don't touch volumes
+    chown "${uid}":"${gid}" /opt/hivemq/data
+    # Any of the following may fail but should still allow HiveMQ to start normally, so lets ignore errors
+    set +e
+    (
     chown "${uid}":"${gid}" /opt/hivemq
     chown "${uid}":"${gid}" /opt/hivemq-*
-    chown "${uid}":"${gid}" /opt/hivemq/data
     chown "${uid}":"${gid}" /opt/hivemq/log
     chown "${uid}":"${gid}" /opt/hivemq/conf
     chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
@@ -50,6 +53,7 @@ if [[ "$(id -u)" = "0" ]]; then
     chmod 700 /opt/hivemq
     chmod 700 /opt/hivemq-*
     chmod -R 700 /opt/hivemq/bin
+    ) 2>/dev/null
 fi
 
 HIVEMQ_BIND_ADDRESS=${ADDR} ${exec_cmd} "$@"


### PR DESCRIPTION
When the underlying platform mounts a volume (specifically as read-only), the current base image entry point will fail to start HiveMQ due to `chown` failing to change the ownership on such volume mounts. (e.g. license folder mount)

This is not intended however, as read-only volumes are acceptable on most paths and we should start up anyway, ignoring such errors.