### PR TITLE
fix-default-HIVEMQ_CONTROL_CENTER_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following environment variables can be used to customize the discovery and b
 | HIVEMQ_CLUSTER_TRANSPORT_TYPE | UDP | Set the *cluster transport* type |
 | HIVEMQ_LICENSE | - | base64 encoded license file to use for the broker |
 | HIVEMQ_CONTROL_CENTER_USER | admin | Set the username for the HiveMQ Control Center login |
-| HIVEMQ_CONTROL_CENTER_PASSWORD | SHA256 of `adminhivemq` (default) | Set the password hash for HiveMQ Control Center authentication |
+| HIVEMQ_CONTROL_CENTER_PASSWORD | SHA256 of `hivemq` (default) | Set the password hash for HiveMQ Control Center authentication |
 | HIVEMQ_NO_ROOT_STEP_DOWN | - | Disable root privilege step-down at startup by setting this to `true`. See [HiveMQ base image](hivemq4/base-image) for more information. |
 | HIVEMQ_ALLOW_ALL_CLIENTS | true | Whether the default packaged allow-all extension (starting from `4.3.0`) should be enabled or not. If this is set to false, the extension will be deleted prior to starting the broker. This flag is inactive for all versions prior to `4.3.0`. |
 | HIVEMQ_REST_API_ENABLED | false | Whether the REST API (supported starting at `4.4.0`) should be enabled or not. If this is set to true, the REST API will bind to `0.0.0.0` on port `8888` at startup. This flag is unused for versions prior to `4.4.0`. |


### PR DESCRIPTION
default HIVEMQ_CONTROL_CENTER_PASSWORD  changed to "hivemq"
ref: (https://www.hivemq.com/docs/hivemq/4.5/control-center/introduction.html)[https://www.hivemq.com/docs/hivemq/4.5/control-center/introduction.html]