### PR TITLE
Minor fixes for permission configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ It can be used with any container orchestration engine that supports service dis
 
 A custom solution supplying the A record could be used as well.
 
+
+## Environment Variables
+
 The following environment variables can be used to customize the discovery and broker configuration respectively.
 
 | Environment Variable | Default value | Meaning |
@@ -101,10 +104,20 @@ The following environment variables can be used to customize the discovery and b
 | HIVEMQ_NO_ROOT_STEP_DOWN | - | Disable root privilege step-down at startup by setting this to `true`. See [HiveMQ base image](hivemq4/base-image) for more information. |
 | HIVEMQ_ALLOW_ALL_CLIENTS | true | Whether the default packaged allow-all extension (starting from `4.3.0`) should be enabled or not. If this is set to false, the extension will be deleted prior to starting the broker. This flag is inactive for all versions prior to `4.3.0`. |
 | HIVEMQ_REST_API_ENABLED | false | Whether the REST API (supported starting at `4.4.0`) should be enabled or not. If this is set to true, the REST API will bind to `0.0.0.0` on port `8888` at startup. This flag is unused for versions prior to `4.4.0`. |
+| HIVEMQ_VERBOSE_ENTRYPOINT | false | Whether the entrypoint scripts should print additional debug info. |
+| HIVEMQ_USE_NSS_WRAPPER | true | Whether nss_wrapper should be used for properly configuring user information. |
 
 Following are two examples, describing how to use this image on Docker Swarm and Kubernetes respectively.
 
 Other environments are compatible as well (provided they support DNS discovery in some way).
+
+## Entrypoint Scripts
+
+There is a `/docker-entrypoint.d` directory which you can `COPY` custom entrypoint scripts to which will be executed before running HiveMQ.
+The scripts must follow the `XX_name.sh` naming scheme, where `XX` is an integer number that will determine the ordering in which the entrypoint scripts are executed.
+
+Depending on the executable bit within the image, they will be either executed normally, or if the executable bit is not set, they will be sourced and run in the parent shell.
+Sourcing allows you to set custom environment variables from an entrypoint script before startup.
 
 ## Local Cluster with Docker Swarm
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -45,7 +45,6 @@ RUN curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o /opt
     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
-    && chgrp -R 0 /opt \
     && chmod -R 775 /opt \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x \
         && curl -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu \
         && curl -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" -o /usr/local/bin/gosu.asc \
         && export GNUPGHOME="$(mktemp -d)" \
-        && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
         && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
         && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
         && { command -v gpgconf && gpgconf --kill all || :; } \

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -45,6 +45,7 @@ RUN curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o /opt
     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
+    && chgrp -R 0 /opt \
     && chmod -R 775 /opt \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -16,12 +16,18 @@ ENV HIVEMQ_REST_API_ENABLED "false"
 # gosu for root step-down to user-privileged process
 ENV GOSU_VERSION 1.11
 
+# Whether we should print additional debug info for the entrypoints
+ENV HIVEMQ_VERBOSE_ENTRYPOINT "false"
+
+# Whether nss_wrapper should be used for starting HiveMQ. Can be disabled for container runtimes that natively fixes the user information in the container at run-time like CRI-O.
+ENV HIVEMQ_USE_NSS_WRAPPER "true"
+
 # Set locale
 ENV LANG=en_US.UTF-8
 
 # gosu setup
 RUN set -x \
-        && apt-get update && apt-get install -y --no-install-recommends curl gnupg-agent gnupg dirmngr unzip \
+        && apt-get update && apt-get install -y --no-install-recommends curl gnupg-agent gnupg dirmngr unzip libnss-wrapper \
         && curl -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu \
         && curl -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" -o /usr/local/bin/gosu.asc \
         && export GNUPGHOME="$(mktemp -d)" \
@@ -31,7 +37,8 @@ RUN set -x \
         && { command -v gpgconf && gpgconf --kill all || :; } \
         && chmod +x /usr/local/bin/gosu \
         && gosu nobody true \
-        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/*
+        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/* \
+        && mkdir -p /docker-entrypoint.d
 
 COPY config.xml /opt/config.xml
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
@@ -48,6 +55,8 @@ RUN curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o /opt
     && chgrp -R 0 /opt \
     && chmod -R 770 /opt \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
+
+COPY entrypoints.d/* /docker-entrypoint.d/
 
 # Substitute eval for exec and replace OOM flag if necessary (for older releases). This is necessary for proper signal propagation
 RUN sed -i -e 's|eval \\"java\\" "$HOME_OPT" "$JAVA_OPTS" -jar "$JAR_PATH"|exec "java" $HOME_OPT $JAVA_OPTS -jar "$JAR_PATH"|' /opt/hivemq/bin/run.sh && \

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -45,7 +45,8 @@ RUN curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o /opt
     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
-    && chmod -R 775 /opt \
+    && chgrp -R 0 /opt \
+    && chmod -R 770 /opt \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
 
 # Substitute eval for exec and replace OOM flag if necessary (for older releases). This is necessary for proper signal propagation

--- a/hivemq4/base-image/docker-entrypoint.sh
+++ b/hivemq4/base-image/docker-entrypoint.sh
@@ -2,83 +2,23 @@
 
 set -eo pipefail
 
-# Decode license and put file if present
-if [[ -n "${HIVEMQ_LICENSE}" ]]; then
-    echo "Decoding license..."
-    echo ${HIVEMQ_LICENSE} | base64 -d > /opt/hivemq/license/license.lic
-fi
-
-# We set the bind address here to ensure HiveMQ uses the correct interface. Defaults to using the container hostname (which should be hardcoded in /etc/hosts)
-if [[ -z "${HIVEMQ_BIND_ADDRESS}" ]]; then
-    echo "Getting bind address from container hostname"
-    ADDR=$(getent hosts ${HOSTNAME} | grep -v 127.0.0.1 | awk '{ print $1 }' | head -n 1)
+if [[ "${HIVEMQ_VERBOSE_ENTRYPOINT}" == "true" ]]; then
+    exec 3>&1
+    set -o xtrace
 else
-    echo "HiveMQ bind address was overridden by environment variable (value: ${HIVEMQ_BIND_ADDRESS})"
-    ADDR=${HIVEMQ_BIND_ADDRESS}
-fi
-
-# Remove allow all extension if applicable
-
-if [[ "${HIVEMQ_ALLOW_ALL_CLIENTS}" != "true" ]]; then
-    echo "Disabling allow all extension"
-    rm -rf /opt/hivemq/extensions/hivemq-allow-all-extension &>/dev/null || true
+    exec 3>/dev/null
 fi
 
 
-if [[ "${HIVEMQ_REST_API_ENABLED}" == "true" ]]; then
-  REST_API_ENABLED_CONFIGURATION="<rest-api>
-        <enabled>true</enabled>
-        <listeners>
-            <http>
-                <port>8888</port>
-                <bind-address>0.0.0.0</bind-address>
-            </http>
-        </listeners>
-    </rest-api>"
-  echo "Enabling REST API in config.xml..."
-  REST_API_ENABLED_CONFIGURATION="${REST_API_ENABLED_CONFIGURATION//$'\n'/}"
-  sed -i "s|<\!--REST-API-CONFIGURATION-->|${REST_API_ENABLED_CONFIGURATION}|" /opt/hivemq/conf/config.xml
-fi
+# Run entrypoint parts
+for f in $(find "/docker-entrypoint.d/" -follow -type f -print | sort -V); do
+  if [ -x "$f" ]; then
+    echo >&3 "$0: running $f"
+    "$f"
+  else
+    echo >&3 "$0: sourcing $f"
+    . "$f"
+  fi
+done
 
-echo "set bind address from container hostname to ${ADDR}"
-export HIVEMQ_BIND_ADDRESS=${ADDR}
-
-# Step down from root privilege, only when we're attempting to run HiveMQ though.
-if [[ "$1" = "/opt/hivemq/bin/run.sh" && "$(id -u)" = '0' && "${HIVEMQ_NO_ROOT_STEP_DOWN}" != "true" ]]; then
-    uid="hivemq"
-    gid="hivemq"
-    exec_cmd="exec gosu hivemq:hivemq"
-else
-    uid="$(id -u)"
-    gid="$(id -g)"
-    exec_cmd="exec"
-fi
-
-readonly uid
-readonly gid
-readonly exec_cmd
-
-if [[ "$(id -u)" = "0" ]]; then
-    # Restrict HiveMQ folder permissions, non-recursive so we don't touch volumes
-    chown "${uid}":"${gid}" /opt/hivemq/data
-    # Any of the following may fail but should still allow HiveMQ to start normally, so lets ignore errors
-    set +e
-    (
-    chown "${uid}":"${gid}" /opt/hivemq
-    chown "${uid}":"${gid}" /opt/hivemq-*
-    chown "${uid}":"${gid}" /opt/hivemq/audit
-    chown "${uid}":"${gid}" /opt/hivemq/log
-    chown "${uid}":"${gid}" /opt/hivemq/conf
-    chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
-    chown "${uid}":"${gid}" /opt/hivemq/license
-    chown "${uid}":"${gid}" /opt/hivemq/backup
-    chown "${uid}":"${gid}" /opt/hivemq/tools
-    # Recursive for bin, no volume here
-    chown -R "${uid}":"${gid}" /opt/hivemq/bin
-    chmod 700 /opt/hivemq
-    chmod 700 /opt/hivemq-*
-    chmod -R 700 /opt/hivemq/bin
-    ) 2>/dev/null
-fi
-
-HIVEMQ_BIND_ADDRESS=${ADDR} ${exec_cmd} "$@"
+${exec_cmd} "$@"

--- a/hivemq4/base-image/entrypoints.d/10_nss_wrapper.sh
+++ b/hivemq4/base-image/entrypoints.d/10_nss_wrapper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ] && [[ ${HIVEMQ_USE_NSS_WRAPPER} = "true" ]]; then
+    USER_ID=$(id -u)
+    GROUP_ID=$(id -g)
+    HOME=/opt/hivemq
+
+    grep -v -e ^hivemq -e "^$USER_ID" /etc/passwd > "$HOME/passwd"
+    echo "hivemq:x:${USER_ID}:${GROUP_ID}:HiveMQ:${HOME}:/bin/false" >> "$HOME/passwd"
+
+    export LD_PRELOAD=/usr/lib/libnss_wrapper.so
+    export NSS_WRAPPER_PASSWD=${HOME}/passwd
+    export NSS_WRAPPER_GROUP=/etc/group
+fi

--- a/hivemq4/base-image/entrypoints.d/20_handle_envs.sh
+++ b/hivemq4/base-image/entrypoints.d/20_handle_envs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Decode license and put file if present
+if [[ -n "${HIVEMQ_LICENSE}" ]]; then
+    echo >&3 "Decoding license..."
+    echo "${HIVEMQ_LICENSE}" | base64 -d > /opt/hivemq/license/license.lic
+fi
+
+# We set the bind address here to ensure HiveMQ uses the correct interface. Defaults to using the container hostname (which should be hardcoded in /etc/hosts)
+if [[ -z "${HIVEMQ_BIND_ADDRESS}" ]]; then
+    echo >&3 "Getting bind address from container hostname"
+    HIVEMQ_BIND_ADDRESS=$(getent hosts ${HOSTNAME} | grep -v 127.0.0.1 | awk '{ print $1 }' | head -n 1)
+else
+    echo >&3 "HiveMQ bind address was overridden by environment variable (value: ${HIVEMQ_BIND_ADDRESS})"
+fi
+
+# Remove allow all extension if applicable
+if [[ "${HIVEMQ_ALLOW_ALL_CLIENTS}" != "true" ]]; then
+    echo "Disabling allow all extension"
+    rm -rf /opt/hivemq/extensions/hivemq-allow-all-extension &>/dev/null || true
+fi
+
+if [[ "${HIVEMQ_REST_API_ENABLED}" == "true" ]]; then
+  REST_API_ENABLED_CONFIGURATION="<rest-api>
+        <enabled>true</enabled>
+        <listeners>
+            <http>
+                <port>8888</port>
+                <bind-address>0.0.0.0</bind-address>
+            </http>
+        </listeners>
+    </rest-api>"
+  echo "Enabling REST API in config.xml..."
+  REST_API_ENABLED_CONFIGURATION="${REST_API_ENABLED_CONFIGURATION//$'\n'/}"
+  sed -i "s|<\!--REST-API-CONFIGURATION-->|${REST_API_ENABLED_CONFIGURATION}|" /opt/hivemq/conf/config.xml
+fi
+
+echo >&3 "setting bind address to ${HIVEMQ_BIND_ADDRESS}"

--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Step down from root privilege, only when we're attempting to run HiveMQ though.
+if [[ "$1" = "/opt/hivemq/bin/run.sh" && "$(id -u)" = '0' && "${HIVEMQ_NO_ROOT_STEP_DOWN}" != "true" ]]; then
+    uid="hivemq"
+    gid="hivemq"
+    exec_cmd="exec gosu hivemq:hivemq"
+else
+    uid="$(id -u)"
+    gid="$(id -g)"
+    exec_cmd="exec"
+fi
+
+readonly uid
+readonly gid
+readonly exec_cmd
+
+if [[ "$(id -u)" = "0" ]]; then
+    # Restrict HiveMQ folder permissions, non-recursive so we don't touch volumes
+    chown "${uid}":"${gid}" /opt/hivemq/data
+    # Any of the following may fail but should still allow HiveMQ to start normally, so lets ignore errors
+    set +e
+    (
+    chown "${uid}":"${gid}" /opt
+    chown "${uid}":"${gid}" /opt/hivemq
+    chown "${uid}":"${gid}" /opt/hivemq-*
+    chown "${uid}":"${gid}" /opt/hivemq/audit
+    chown "${uid}":"${gid}" /opt/hivemq/log
+    chown "${uid}":"${gid}" /opt/hivemq/conf
+    chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
+    chown "${uid}":"${gid}" /opt/hivemq/license
+    chown "${uid}":"${gid}" /opt/hivemq/backup
+    chown "${uid}":"${gid}" /opt/hivemq/tools
+    chown "${uid}":"${gid}" /opt/hivemq/extensions
+    # Recursive for bin, no volume here
+    chown -R "${uid}":"${gid}" /opt/hivemq/bin
+    chmod 700 /opt/hivemq
+    chmod 700 /opt/hivemq-*
+    chmod -R 700 /opt/hivemq/bin
+    ) 2>/dev/null
+fi

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -25,8 +25,4 @@ RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/rel
 
 COPY pre-entry.sh /opt/pre-entry.sh
 
-RUN chmod +x /opt/docker-entrypoint.sh \
-    && chmod +x /opt/pre-entry.sh
-
-ENTRYPOINT ["/opt/pre-entry.sh"]
-CMD ["/opt/hivemq/bin/run.sh"]
+RUN chmod +x /opt/pre-entry.sh && ln -s /opt/pre-entry.sh /docker-entrypoint.d/40_dns_entrypoint.sh

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -15,7 +15,7 @@ ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE UDP
 COPY config-dns.xml /opt/hivemq/conf/config.xml
 
 RUN mkdir /opt/hivemq/extensions/hivemq-dns-cluster-discovery
-COPY --chmod=775 hivemq-dns-cluster-discovery/* /opt/hivemq/extensions/hivemq-dns-cluster-discovery/
+COPY hivemq-dns-cluster-discovery/* /opt/hivemq/extensions/hivemq-dns-cluster-discovery/
 
 COPY pre-entry.sh /opt/pre-entry.sh
 

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -15,13 +15,12 @@ ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE UDP
 COPY config-dns.xml /opt/hivemq/conf/config.xml
 
 RUN mkdir /opt/hivemq/extensions/hivemq-dns-cluster-discovery
-COPY hivemq-dns-cluster-discovery/* /opt/hivemq/extensions/hivemq-dns-cluster-discovery/
+COPY --chmod=775 hivemq-dns-cluster-discovery/* /opt/hivemq/extensions/hivemq-dns-cluster-discovery/
 
 COPY pre-entry.sh /opt/pre-entry.sh
 
 RUN chmod +x /opt/docker-entrypoint.sh \
-    && chmod +x /opt/pre-entry.sh \
-    && chown -R hivemq:hivemq /opt/hivemq
+    && chmod +x /opt/pre-entry.sh
 
 ENTRYPOINT ["/opt/pre-entry.sh"]
 CMD ["/opt/hivemq/bin/run.sh"]

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -14,8 +14,11 @@ ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE UDP
 
 COPY config-dns.xml /opt/hivemq/conf/config.xml
 
-RUN mkdir /opt/hivemq/extensions/hivemq-dns-cluster-discovery
-COPY hivemq-dns-cluster-discovery/* /opt/hivemq/extensions/hivemq-dns-cluster-discovery/
+RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/download/4.1.0/hivemq-dns-cluster-discovery-4.1.0.zip -o /opt/hivemq/extensions/dns-discovery.zip \
+    && unzip /opt/hivemq/extensions/dns-discovery.zip -d /opt/hivemq/extensions \
+    && rm -f /opt/hivemq/extensions/hivemq-dns-cluster-discovery/*.png \
+    && chmod -R 775 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
+    && rm /opt/hivemq/extensions/dns-discovery.zip
 
 COPY pre-entry.sh /opt/pre-entry.sh
 

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -2,6 +2,8 @@ ARG BASEIMAGE=hivemq/hivemq4:latest
 
 FROM ${BASEIMAGE}
 
+ARG DNS_DISCOVERY_EXTENSION_VERSION=4.1.0
+
 # Use default DNS resolution timeout as default discovery interval
 ENV HIVEMQ_DNS_DISCOVERY_INTERVAL 31
 ENV HIVEMQ_DNS_DISCOVERY_TIMEOUT 30
@@ -14,7 +16,7 @@ ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE UDP
 
 COPY config-dns.xml /opt/hivemq/conf/config.xml
 
-RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/download/4.1.0/hivemq-dns-cluster-discovery-4.1.0.zip -o /opt/hivemq/extensions/dns-discovery.zip \
+RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/download/${DNS_DISCOVERY_EXTENSION_VERSION}/hivemq-dns-cluster-discovery-${DNS_DISCOVERY_EXTENSION_VERSION}.zip -o /opt/hivemq/extensions/dns-discovery.zip \
     && unzip /opt/hivemq/extensions/dns-discovery.zip -d /opt/hivemq/extensions \
     && rm -f /opt/hivemq/extensions/hivemq-dns-cluster-discovery/*.png \
     && chgrp -R 0 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -17,7 +17,8 @@ COPY config-dns.xml /opt/hivemq/conf/config.xml
 RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/download/4.1.0/hivemq-dns-cluster-discovery-4.1.0.zip -o /opt/hivemq/extensions/dns-discovery.zip \
     && unzip /opt/hivemq/extensions/dns-discovery.zip -d /opt/hivemq/extensions \
     && rm -f /opt/hivemq/extensions/hivemq-dns-cluster-discovery/*.png \
-    && chmod -R 775 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
+    && chgrp -R 0 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
+    && chmod -R 770 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
     && rm /opt/hivemq/extensions/dns-discovery.zip
 
 COPY pre-entry.sh /opt/pre-entry.sh

--- a/hivemq4/dns-image/pre-entry.sh
+++ b/hivemq4/dns-image/pre-entry.sh
@@ -7,5 +7,3 @@ elif [[ "${HIVEMQ_CLUSTER_TRANSPORT_TYPE}" == "TCP" ]]; then
     # shellcheck disable=SC2016
     sed -i -e 's|<\!--TRANSPORT_TYPE-->|<tcp><bind-address>${HIVEMQ_BIND_ADDRESS}</bind-address><bind-port>${HIVEMQ_CLUSTER_PORT}</bind-port></tcp>|' /opt/hivemq/conf/config.xml
 fi
-
-exec /opt/docker-entrypoint.sh "$@"


### PR DESCRIPTION
we should not chown to anything other than root at build-time to ensure the image will work on environments that set arbitrary UIDs on startup for security reasons (such as K8s with securityContext or openshift for example)

* update key server used in base image to the new recommended one for gosu (build was broken)
* update dns extension version + install procedure to use proper permissions
