### PR TITLE
Invalid permissions on regular run

### DIFF
--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -16,5 +16,5 @@ readonly gid
 readonly exec_cmd
 
 if [[ "$(id -u)" = "0" ]]; then
-    find /opt \! -user "${uid}" -exec chown "${uid}" '{}' + || true 2>&3
+    find /opt \! -user "${uid}" -exec chown "${uid}" '{}' + 2>&3 || true
 fi

--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -24,14 +24,14 @@ if [[ "$(id -u)" = "0" ]]; then
     chown "${uid}":"${gid}" /opt
     chown "${uid}":"${gid}" /opt/hivemq
     chown "${uid}":"${gid}" /opt/hivemq-*
-    chown "${uid}":"${gid}" /opt/hivemq/audit
-    chown "${uid}":"${gid}" /opt/hivemq/log
-    chown "${uid}":"${gid}" /opt/hivemq/conf
-    chown "${uid}":"${gid}" /opt/hivemq/conf/config.xml
-    chown "${uid}":"${gid}" /opt/hivemq/license
-    chown "${uid}":"${gid}" /opt/hivemq/backup
-    chown "${uid}":"${gid}" /opt/hivemq/tools
-    chown "${uid}":"${gid}" /opt/hivemq/extensions
+    chown -R "${uid}":"${gid}" /opt/hivemq/audit
+    chown -R "${uid}":"${gid}" /opt/hivemq/log
+    chown -R "${uid}":"${gid}" /opt/hivemq/conf
+    chown -R "${uid}":"${gid}" /opt/hivemq/conf/config.xml
+    chown -R "${uid}":"${gid}" /opt/hivemq/license
+    chown -R "${uid}":"${gid}" /opt/hivemq/backup
+    chown -R "${uid}":"${gid}" /opt/hivemq/tools
+    chown -R "${uid}":"${gid}" /opt/hivemq/extensions
     # Recursive for bin, no volume here
     chown -R "${uid}":"${gid}" /opt/hivemq/bin
     chmod 700 /opt/hivemq

--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -16,5 +16,5 @@ readonly gid
 readonly exec_cmd
 
 if [[ "$(id -u)" = "0" ]]; then
-    find -L /opt \! -user hivemq -exec chown hivemq '{}' +
+    find /opt \! -user "${uid}" -exec chown "${uid}" '{}' + || true >&3
 fi

--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -16,5 +16,5 @@ readonly gid
 readonly exec_cmd
 
 if [[ "$(id -u)" = "0" ]]; then
-    find /opt \! -user "${uid}" -exec chown "${uid}" '{}' + || true >&3
+    find /opt \! -user "${uid}" -exec chown "${uid}" '{}' + || true 2>&3
 fi

--- a/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
+++ b/hivemq4/base-image/entrypoints.d/30_configure_permissions.sh
@@ -4,7 +4,7 @@
 if [[ "$1" = "/opt/hivemq/bin/run.sh" && "$(id -u)" = '0' && "${HIVEMQ_NO_ROOT_STEP_DOWN}" != "true" ]]; then
     uid="hivemq"
     gid="hivemq"
-    exec_cmd="exec gosu hivemq:hivemq"
+    exec_cmd="exec gosu hivemq"
 else
     uid="$(id -u)"
     gid="$(id -g)"
@@ -16,26 +16,5 @@ readonly gid
 readonly exec_cmd
 
 if [[ "$(id -u)" = "0" ]]; then
-    # Restrict HiveMQ folder permissions, non-recursive so we don't touch volumes
-    chown "${uid}":"${gid}" /opt/hivemq/data
-    # Any of the following may fail but should still allow HiveMQ to start normally, so lets ignore errors
-    set +e
-    (
-    chown "${uid}":"${gid}" /opt
-    chown "${uid}":"${gid}" /opt/hivemq
-    chown "${uid}":"${gid}" /opt/hivemq-*
-    chown -R "${uid}":"${gid}" /opt/hivemq/audit
-    chown -R "${uid}":"${gid}" /opt/hivemq/log
-    chown -R "${uid}":"${gid}" /opt/hivemq/conf
-    chown -R "${uid}":"${gid}" /opt/hivemq/conf/config.xml
-    chown -R "${uid}":"${gid}" /opt/hivemq/license
-    chown -R "${uid}":"${gid}" /opt/hivemq/backup
-    chown -R "${uid}":"${gid}" /opt/hivemq/tools
-    chown -R "${uid}":"${gid}" /opt/hivemq/extensions
-    # Recursive for bin, no volume here
-    chown -R "${uid}":"${gid}" /opt/hivemq/bin
-    chmod 700 /opt/hivemq
-    chmod 700 /opt/hivemq-*
-    chmod -R 700 /opt/hivemq/bin
-    ) 2>/dev/null
+    find -L /opt \! -user hivemq -exec chown hivemq '{}' +
 fi


### PR DESCRIPTION
Running the base-image directly currently leads to errors indicating invalid permissions.
The cause seems to be that in https://github.com/hivemq/hivemq4-docker-images/pull/26 we removed an actually incorrect chmod https://github.com/hivemq/hivemq4-docker-images/pull/26/files#diff-d95a41d0aa7ba0821046381e74a9bb6c2d52dca7eb76e5ab7fdd8e0b5408ac11L48
which allowed the extensions + configs to be read at least.

Now that we use proper 770 permissions, this fails as the chown in the step-down branch is non-recursive, so configs + extension files have root:root ownership but no other read privilege.

We chose to switch the permission fixing to a find command. Other well-tested images like [redis](https://github.com/docker-library/redis/blob/af431c381c3718dbe4d87572f7d3c330a063df8d/6.2/docker-entrypoint.sh#L10-L14) use this approach as well.
The end-result is similar, with the key difference that this will reliably recurse into all directories and selectively `chown` the files whose permission is incorrect. (This also gives some performance gain as we don't chown all files always).
The errors from K8s volumes for example (which are read-only and cannot be `chown`ed but are configured with proper permissions by K8s) are suppressed and redirected to the verbose fd (can be enabled with `HIVEMQ_VERBOSE_ENTRYPOINT=true`)

As result: 
- docker run for the base image works as expected again
- the k8s derivate works properly with default (restricted) securityContext as well as a fairly lenient (root) securityContext with privilege step-down.