### PR TITLE
Fix DNS image bind address config

### DIFF
--- a/hivemq4/base-image/entrypoints.d/20_handle_envs.sh
+++ b/hivemq4/base-image/entrypoints.d/20_handle_envs.sh
@@ -10,6 +10,7 @@ fi
 if [[ -z "${HIVEMQ_BIND_ADDRESS}" ]]; then
     echo >&3 "Getting bind address from container hostname"
     HIVEMQ_BIND_ADDRESS=$(getent hosts ${HOSTNAME} | grep -v 127.0.0.1 | awk '{ print $1 }' | head -n 1)
+    export HIVEMQ_BIND_ADDRESS
 else
     echo >&3 "HiveMQ bind address was overridden by environment variable (value: ${HIVEMQ_BIND_ADDRESS})"
 fi


### PR DESCRIPTION
It seems that we missed this in the original PR.
The bind address env doesn't properly carry over to the call site (docker-entrypoint.sh), leading to the bind address env not being set when HiveMQ actually starts