### PR TITLE
build platform docker images from zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is meant to be used to build custom images or to run a dockerized HiveMQ loca
 
 ### How to Build
 
-The image can then be built by running the command `VERSION=4.7.3 ./build.sh` in the `hivemq4/base-image` folder.
+The image can then be built by running the command `HIVEMQ_VERSION=4.7.3 ./build.sh` in the `hivemq4/base-image` folder. An alternative image name can be specified with the environment variable `TARGETIMAGE`, example: `TARGETIMAGE=myregistry/custom-hivemq:1.2.3 HIVEMQ_VERSION=4.7.3 ./build.sh`
 
 ## HiveMQ DNS Discovery Image
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is meant to be used to build custom images or to run a dockerized HiveMQ loca
 
 ### How to Build
 
-The image can then be built by running `docker build -t hivemq .` in the `hivemq4/base-image` folder. To specify the version the argument `--build-arg HIVEMQ_VERSION=4.5.0` can be specified, by running the command `docker build --build-arg HIVEMQ_VERSION=4.5.0 -t hivemq .`.
+The image can then be built by running the command `VERSION=4.7.3 ./build.sh` in the `hivemq4/base-image` folder.
 
 ## HiveMQ DNS Discovery Image
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -51,12 +51,11 @@ RUN set -x \
         && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/* \
         && mkdir -p /docker-entrypoint.d
 
-COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/
-COPY config.xml /opt/config.xml
+COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq-${HIVEMQ_VERSION}
+COPY config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
 
 RUN ln -s /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq \
-    && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
     && chgrp 0 /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -1,5 +1,19 @@
-FROM openjdk:11-jre-slim as javabase
+#Additional build image to unpack the zip file and change the permissions without retaining large layers just for those operations
+FROM busybox as unpack
 
+ARG HIVEMQ_VERSION
+
+COPY config.xml /opt/config.xml
+COPY hivemq-${HIVEMQ_VERSION}.zip /opt/hivemq-${HIVEMQ_VERSION}.zip
+RUN  unzip /opt/hivemq-${HIVEMQ_VERSION}.zip  -d /opt/ \
+     && rm -rf /opt/hivemq-${HIVEMQ_VERSION}/tools/hivemq-swarm \
+     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
+     && chgrp -R 0 /opt \
+     && chmod -R 770 /opt
+
+FROM openjdk:11-jre-slim
+
+ARG HIVEMQ_VERSION
 ENV HIVEMQ_GID=10000
 ENV HIVEMQ_UID=10000
 
@@ -36,38 +50,24 @@ RUN set -x \
         && { command -v gpgconf && gpgconf --kill all || :; } \
         && chmod +x /usr/local/bin/gosu \
         && gosu nobody true \
-        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/*
+        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/* \
+        && mkdir -p /docker-entrypoint.d
 
-
-#Additional build image to unpack the zip file and change the permissions without retaining large layers just for those operations
-FROM javabase as unpack
-
-ARG HIVEMQ_VERSION=4.0.0
-
+COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/
 COPY config.xml /opt/config.xml
-COPY hivemq-${HIVEMQ_VERSION}.zip /opt/hivemq-${HIVEMQ_VERSION}.zip
-RUN  unzip /opt/hivemq-${HIVEMQ_VERSION}.zip  -d /opt/ \
-     && rm -rf /opt/hivemq-${HIVEMQ_VERSION}/tools/hivemq-swarm \
-     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
-     && chgrp -R 0 /opt \
-     && chmod -R 770 /opt
-
-FROM javabase
-
-ARG HIVEMQ_VERSION=4.0.0
-
-COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
-COPY entrypoints.d/* /docker-entrypoint.d/
 
-RUN mkdir -p /docker-entrypoint.d \
+RUN ln -s /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq \
+    && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
+    && chgrp 0 /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
+    && chmod 770 /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
+    && chgrp 0 /opt/hivemq \
+    && chmod 770 /opt/hivemq \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
 
-# Substitute eval for exec and replace OOM flag if necessary (for older releases). This is necessary for proper signal propagation
-RUN sed -i -e 's|eval \\"java\\" "$HOME_OPT" "$JAVA_OPTS" -jar "$JAR_PATH"|exec "java" $HOME_OPT $JAVA_OPTS -jar "$JAR_PATH"|' /opt/hivemq/bin/run.sh && \
-    sed -i -e "s|-XX:OnOutOfMemoryError='sleep 5; kill -9 %p'|-XX:+CrashOnOutOfMemoryError|" /opt/hivemq/bin/run.sh
+COPY entrypoints.d/* /docker-entrypoint.d/
 
 # Make broker data persistent throughout stop/start cycles
 VOLUME /opt/hivemq/data

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -3,11 +3,9 @@ FROM busybox as unpack
 
 ARG HIVEMQ_VERSION
 
-COPY config.xml /opt/config.xml
 COPY hivemq-${HIVEMQ_VERSION}.zip /opt/hivemq-${HIVEMQ_VERSION}.zip
 RUN  unzip /opt/hivemq-${HIVEMQ_VERSION}.zip  -d /opt/ \
      && rm -rf /opt/hivemq-${HIVEMQ_VERSION}/tools/hivemq-swarm \
-     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
      && chgrp -R 0 /opt \
      && chmod -R 770 /opt
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -54,6 +54,7 @@ RUN set -x \
 COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq-${HIVEMQ_VERSION}
 COPY config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+COPY entrypoints.d/* /docker-entrypoint.d/
 
 RUN ln -s /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
@@ -64,22 +65,16 @@ RUN ln -s /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq \
     && chmod 770 /opt/hivemq \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
 
-COPY entrypoints.d/* /docker-entrypoint.d/
-
 # Make broker data persistent throughout stop/start cycles
 VOLUME /opt/hivemq/data
 
 # Persist log data
 VOLUME /opt/hivemq/log
 
-#mqtt-clients
-EXPOSE 1883
-
-#websockets
-EXPOSE 8000
-
-#HiveMQ Control Center
-EXPOSE 8080
+# MQTT TCP listener: 1883
+# MQTT Websocket listener: 8000
+# HiveMQ Control Center: 8080
+EXPOSE 1883 8000 8080
 
 WORKDIR /opt/hivemq
 

--- a/hivemq4/base-image/Dockerfile
+++ b/hivemq4/base-image/Dockerfile
@@ -1,6 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:11-jre-slim as javabase
 
-ARG HIVEMQ_VERSION=4.0.0
 ENV HIVEMQ_GID=10000
 ENV HIVEMQ_UID=10000
 
@@ -37,26 +36,34 @@ RUN set -x \
         && { command -v gpgconf && gpgconf --kill all || :; } \
         && chmod +x /usr/local/bin/gosu \
         && gosu nobody true \
-        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/* \
-        && mkdir -p /docker-entrypoint.d
+        && apt-get purge -y gpg dirmngr && rm -rf /var/lib/apt/lists/*
+
+
+#Additional build image to unpack the zip file and change the permissions without retaining large layers just for those operations
+FROM javabase as unpack
+
+ARG HIVEMQ_VERSION=4.0.0
 
 COPY config.xml /opt/config.xml
-COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+COPY hivemq-${HIVEMQ_VERSION}.zip /opt/hivemq-${HIVEMQ_VERSION}.zip
+RUN  unzip /opt/hivemq-${HIVEMQ_VERSION}.zip  -d /opt/ \
+     && rm -rf /opt/hivemq-${HIVEMQ_VERSION}/tools/hivemq-swarm \
+     && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
+     && chgrp -R 0 /opt \
+     && chmod -R 770 /opt
 
-# HiveMQ setup
-RUN curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o /opt/hivemq-${HIVEMQ_VERSION}.zip \
-    && unzip /opt/hivemq-${HIVEMQ_VERSION}.zip  -d /opt/\
-    && rm -f /opt/hivemq-${HIVEMQ_VERSION}.zip \
-    && rm -rf /opt/hivemq-${HIVEMQ_VERSION}/tools/hivemq-swarm \
-    && ln -s /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq \
-    && mv /opt/config.xml /opt/hivemq-${HIVEMQ_VERSION}/conf/config.xml \
+FROM javabase
+
+ARG HIVEMQ_VERSION=4.0.0
+
+COPY --from=unpack /opt/hivemq-${HIVEMQ_VERSION} /opt/hivemq
+COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+COPY entrypoints.d/* /docker-entrypoint.d/
+
+RUN mkdir -p /docker-entrypoint.d \
     && groupadd --gid ${HIVEMQ_GID} hivemq \
     && useradd -g hivemq -d /opt/hivemq -s /bin/bash --uid ${HIVEMQ_UID} hivemq \
-    && chgrp -R 0 /opt \
-    && chmod -R 770 /opt \
     && chmod +x /opt/hivemq/bin/run.sh /opt/docker-entrypoint.sh
-
-COPY entrypoints.d/* /docker-entrypoint.d/
 
 # Substitute eval for exec and replace OOM flag if necessary (for older releases). This is necessary for proper signal propagation
 RUN sed -i -e 's|eval \\"java\\" "$HOME_OPT" "$JAVA_OPTS" -jar "$JAR_PATH"|exec "java" $HOME_OPT $JAVA_OPTS -jar "$JAR_PATH"|' /opt/hivemq/bin/run.sh && \

--- a/hivemq4/base-image/build.sh
+++ b/hivemq4/base-image/build.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${DIR}
 
-HIVEMQ_VERSION=${VERSION:-4.7.3}
 IMAGE_NAME=${TARGETIMAGE:-hivemq/hivemq4:$HIVEMQ_VERSION}
 
 #download HiveMQ binary

--- a/hivemq4/base-image/build.sh
+++ b/hivemq4/base-image/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#set -o xtrace
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}
+
+HIVEMQ_VERSION=${VERSION:-4.7.3}
+IMAGE_NAME=${TARGETIMAGE:-hivemq/hivemq4:$HIVEMQ_VERSION}
+
+#download HiveMQ binary
+[ -f "hivemq-${HIVEMQ_VERSION}.zip" ] || (curl -L https://www.hivemq.com/releases/hivemq-${HIVEMQ_VERSION}.zip -o hivemq-${HIVEMQ_VERSION}.zip)
+
+#build docker image
+docker build --build-arg HIVEMQ_VERSION=${HIVEMQ_VERSION} -f Dockerfile . -t ${IMAGE_NAME}

--- a/hivemq4/base-image/build.sh
+++ b/hivemq4/base-image/build.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-
-#set -o xtrace
+set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${DIR}

--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -15,14 +15,13 @@ ENV HIVEMQ_CONTROL_CENTER_PASSWORD a68fc32fc49fc4d04c63724a1f6d0c90442209c46dba6
 ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE UDP
 
 COPY config-dns.xml /opt/hivemq/conf/config.xml
+COPY pre-entry.sh /opt/pre-entry.sh
 
 RUN curl -L https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/download/${DNS_DISCOVERY_EXTENSION_VERSION}/hivemq-dns-cluster-discovery-${DNS_DISCOVERY_EXTENSION_VERSION}.zip -o /opt/hivemq/extensions/dns-discovery.zip \
     && unzip /opt/hivemq/extensions/dns-discovery.zip -d /opt/hivemq/extensions \
     && rm -f /opt/hivemq/extensions/hivemq-dns-cluster-discovery/*.png \
     && chgrp -R 0 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
     && chmod -R 770 /opt/hivemq/extensions/hivemq-dns-cluster-discovery \
-    && rm /opt/hivemq/extensions/dns-discovery.zip
-
-COPY pre-entry.sh /opt/pre-entry.sh
-
-RUN chmod +x /opt/pre-entry.sh && ln -s /opt/pre-entry.sh /docker-entrypoint.d/40_dns_entrypoint.sh
+    && rm /opt/hivemq/extensions/dns-discovery.zip \
+    && chmod +x /opt/pre-entry.sh \
+    && ln -s /opt/pre-entry.sh /docker-entrypoint.d/40_dns_entrypoint.sh


### PR DESCRIPTION
build platform docker images from zip

changes: 
- A hivemq.zip file can be used instead of a download from the website
- Use a multistage build to keep the layer size small