### PR TITLE
[4.8] Move k8s image to the containers project

### DIFF
--- a/hivemq4/k8s-image/Dockerfile
+++ b/hivemq4/k8s-image/Dockerfile
@@ -1,0 +1,47 @@
+ARG BASE_IMAGE=hivemq/hivemq4:dns-latest
+ARG HIVEMQ_VERSION=4.7.5
+ARG PROMETHEUS_EXTENSION_VERSION=4.0.4
+
+FROM busybox as BUILD
+ARG HIVEMQ_VERSION
+ARG PROMETHEUS_EXTENSION_VERSION
+
+WORKDIR /opt/hivemq/extensions
+
+COPY hivemq-k8s-sync-extension-"${HIVEMQ_VERSION}".zip ./hivemq-k8s-sync-extension.zip
+RUN unzip hivemq-k8s-sync-extension.zip -d /opt/hivemq/extensions/hivemq-k8s-sync-extension \
+    && rm hivemq-k8s-sync-extension.zip
+
+ADD https://www.hivemq.com/releases/extensions/hivemq-prometheus-extension-"${PROMETHEUS_EXTENSION_VERSION}".zip ./hivemq-prometheus-extension.zip
+RUN unzip hivemq-prometheus-extension.zip -d /opt/hivemq/extensions/hivemq-prometheus-extension \
+    && rm hivemq-prometheus-extension.zip
+COPY prometheusConfiguration.properties /opt/hivemq/extensions/hivemq-prometheus-extension/
+## Clean image to distribute
+FROM ${BASE_IMAGE}
+
+ENV HIVEMQ_LOG_LEVEL INFO
+ENV HIVEMQ_CLUSTER_TRANSPORT_TYPE TCP
+
+COPY config.xml /opt/hivemq/conf/config.xml
+COPY scripts/*.sh /opt/hivemq/bin/
+COPY --from=BUILD /opt/hivemq/extensions/* /opt/hivemq/extensions/
+
+### Move the entrypoint into the correct position & adjust for whether the base image uses entrypoint.d or not
+### Fix permissions as --chmod on COPY is not really working at the moment and requires buildkit
+RUN rm /opt/hivemq/extensions/prometheusConfiguration.properties \
+    && chmod +x /opt/hivemq/bin/*.sh \
+    && if [ -d /docker-entrypoint.d ]; then \
+      mv /opt/hivemq/bin/pre-entry_1.sh /docker-entrypoint.d/15_k8s_entrypoint.sh && \
+      ln -s /opt/docker-entrypoint.sh /opt/hivemq/bin/pre-entry_1.sh; \
+    else \
+      echo '# Pass on to DNS entrypoint' >> /opt/hivemq/bin/pre-entry_1.sh && \
+      echo 'exec /opt/pre-entry.sh "$@"' >> /opt/hivemq/bin/pre-entry_1.sh; \
+    fi \
+    && chmod -R 770 /opt/hivemq/extensions/hivemq-k8s-sync-extension \
+    && chgrp -R 0 /opt/hivemq/extensions/hivemq-k8s-sync-extension \
+    && chmod -R 770 /opt/hivemq/extensions/hivemq-prometheus-extension \
+    && chgrp -R 0 /opt/hivemq/extensions/hivemq-prometheus-extension \
+    && chmod -R 770 /opt/hivemq/extensions/hivemq-k8s-sync-extension && chmod -R 770 /opt/hivemq/conf/config.xml
+
+ENTRYPOINT ["/opt/hivemq/bin/pre-entry_1.sh"]
+CMD ["/opt/hivemq/bin/run.sh"]

--- a/hivemq4/k8s-image/config.xml
+++ b/hivemq4/k8s-image/config.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<hivemq xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="hivemq-config.xsd">
+    <listeners>
+        --LISTENER-CONFIGURATION--
+    </listeners>
+    <control-center>
+        <listeners>
+            <http>
+                <port>${HIVEMQ_CONTROL_CENTER_PORT}</port>
+                <bind-address>0.0.0.0</bind-address>
+            </http>
+        </listeners>
+        <users>
+            <user>
+                <name>${HIVEMQ_CONTROL_CENTER_USER}</name>
+                <password>${HIVEMQ_CONTROL_CENTER_PASSWORD}</password>
+            </user>
+        </users>
+    </control-center>
+
+    <!--REST-API-CONFIGURATION-->
+    <cluster>
+        <enabled>true</enabled>
+        <transport>
+            <tcp>
+                <bind-address>${HIVEMQ_BIND_ADDRESS}</bind-address>
+                <bind-port>${HIVEMQ_CLUSTER_PORT}</bind-port>
+                <enabled>true</enabled>
+            </tcp>
+        </transport>
+        <discovery>
+            <extension>
+                <reload-interval>${HIVEMQ_DNS_DISCOVERY_INTERVAL}</reload-interval>
+            </extension>
+        </discovery>
+
+        <replication>
+            <replica-count>${HIVEMQ_CLUSTER_REPLICA_COUNT}</replica-count>
+        </replication>
+
+        <failure-detection>
+            <tcp-health-check>
+                <enabled>true</enabled>
+                <bind-address>${HIVEMQ_BIND_ADDRESS}</bind-address>
+                <bind-port>9000</bind-port>
+                <port-range>50</port-range>
+            </tcp-health-check>
+
+            <heartbeat>
+                <enabled>true</enabled>
+                <interval>4000</interval>
+                <timeout>30000</timeout>
+            </heartbeat>
+        </failure-detection>
+
+    </cluster>
+    <overload-protection>
+        <enabled>${HIVEMQ_CLUSTER_OVERLOAD_PROTECTION}</enabled>
+    </overload-protection>
+    <restrictions>
+        <max-client-id-length>${HIVEMQ_MAX_CLIENT_ID_LENGTH}</max-client-id-length>
+        <max-topic-length>${HIVEMQ_MAX_TOPIC_LENGTH}</max-topic-length>
+        <max-connections>-${HIVEMQ_MAX_CONNECTIONS}</max-connections>
+        <incoming-bandwidth-throttling>${HIVEMQ_INCOMING_BANDWIDTH_THROTTLING}</incoming-bandwidth-throttling>
+        <no-connect-idle-timeout>${HIVEMQ_NO_CONNECT_IDLE_TIMEOUT}</no-connect-idle-timeout>
+    </restrictions>
+    <mqtt>
+        <session-expiry>
+            <max-interval>${HIVEMQ_SESSION_EXPIRY_INTERVAL}</max-interval>
+        </session-expiry>
+
+        <message-expiry>
+            <max-interval>${HIVEMQ_MESSAGE_EXPIRY_MAX_INTERVAL}</max-interval>
+        </message-expiry>
+
+        <packets>
+            <max-packet-size>${HIVEMQ_MAX_PACKET_SIZE}</max-packet-size>
+        </packets>
+
+        <receive-maximum>
+            <server-receive-maximum>${HIVEMQ_SERVER_RECEIVE_MAXIMUM}</server-receive-maximum>
+        </receive-maximum>
+
+        <keep-alive>
+            <max-keep-alive>${HIVEMQ_KEEPALIVE_MAX}</max-keep-alive>
+            <allow-unlimited>${HIVEMQ_KEEPALIVE_ALLOW_UNLIMITED}</allow-unlimited>
+        </keep-alive>
+
+        <topic-alias>
+            <enabled>${HIVEMQ_TOPIC_ALIAS_ENABLED}</enabled>
+            <max-per-client>${HIVEMQ_TOPIC_ALIAS_MAX_PER_CLIENT}</max-per-client>
+        </topic-alias>
+
+        <subscription-identifier>
+            <enabled>${HIVEMQ_SUBSCRIPTION_IDENTIFIER_ENABLED}</enabled>
+        </subscription-identifier>
+
+        <wildcard-subscriptions>
+            <enabled>${HIVEMQ_WILDCARD_SUBSCRIPTION_ENABLED}</enabled>
+        </wildcard-subscriptions>
+
+        <shared-subscriptions>
+            <enabled>${HIVEMQ_SHARED_SUBSCRIPTION_ENABLED}</enabled>
+        </shared-subscriptions>
+
+        <quality-of-service>
+            <max-qos>${HIVEMQ_MAX_QOS}</max-qos>
+        </quality-of-service>
+
+        <retained-messages>
+            <enabled>${HIVEMQ_RETAINED_MESSAGES_ENABLED}</enabled>
+        </retained-messages>
+
+        <queued-messages>
+            <max-queue-size>${HIVEMQ_QUEUED_MESSAGE_MAX_QUEUE_SIZE}</max-queue-size>
+            <strategy>${HIVEMQ_QUEUED_MESSAGE_STRATEGY}</strategy>
+        </queued-messages>
+    </mqtt>
+    <security>
+        <!-- Allows the use of empty client ids -->
+        <allow-empty-client-id>
+            <enabled>${HIVEMQ_ALLOW_EMPTY_CLIENT_ID}</enabled>
+        </allow-empty-client-id>
+
+        <!-- Configures validation for UTF-8 PUBLISH payloads -->
+        <payload-format-validation>
+            <enabled>${HIVEMQ_PAYLOAD_FORMAT_VALIDATION}</enabled>
+        </payload-format-validation>
+
+        <utf8-validation>
+            <enabled>${HIVEMQ_TOPIC_FORMAT_VALIDATION}</enabled>
+        </utf8-validation>
+
+        <!-- Allows clients to request problem information -->
+        <allow-request-problem-information>
+            <enabled>${HIVEMQ_ALLOW_REQUEST_PROBLEM_INFORMATION}</enabled>
+        </allow-request-problem-information>
+
+        <control-center-audit-log>
+            <enabled>${HIVEMQ_CONTROL_CENTER_AUDIT_LOG_ENABLED}</enabled>
+        </control-center-audit-log>
+    </security>
+</hivemq>

--- a/hivemq4/k8s-image/prometheusConfiguration.properties
+++ b/hivemq4/k8s-image/prometheusConfiguration.properties
@@ -1,0 +1,3 @@
+ip=0.0.0.0
+port=9399
+metric_path=/

--- a/hivemq4/k8s-image/scripts/heap.sh
+++ b/hivemq4/k8s-image/scripts/heap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Create a heap dump to /opt/hivemq/heap-dump.hprof
+
+curl -L https://github.com/apangin/jattach/releases/download/v1.5/jattach > jattach
+chmod +x jattach
+./jattach 1 dumpheap heap-dump.hprof
+

--- a/hivemq4/k8s-image/scripts/install_extension.sh
+++ b/hivemq4/k8s-image/scripts/install_extension.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# This will also be part of a proper API at some point
+
+set -eo pipefail
+
+set -o xtrace
+
+if [[ $# != 3 ]]; then
+    echo "Usage: $0 <extensionUri> <extension-name> <desired-state>"
+    exit 1
+fi
+
+EXTENSION_URI="$1"
+EXTENSION_NAME="$2"
+TARGET_STATE="$3"
+TARGET_DIR="/opt/hivemq/extensions/${EXTENSION_NAME}"
+install_dir=$(mktemp -d)
+
+set +e
+[[ -f ${TARGET_DIR}/DISABLED ]]
+was_enabled=$?
+
+set -e
+
+if [[ "${EXTENSION_URI}" != "preinstalled" ]]; then
+    cd "${install_dir}"
+    curl -L "${EXTENSION_URI}" --output extension.zip
+    unzip extension.zip
+    if [[ -d "${TARGET_DIR}" && -f "${TARGET_DIR}/hivemq-extension.xml" ]]; then
+        echo "Extension already installed"
+        if [[ "${was_enabled}" == "1" ]]; then
+            echo "Extension is currently running, making sure it's disabled first"
+            touch ${TARGET_DIR}/DISABLED
+            EXT_NAME=$(cat ${TARGET_DIR}/hivemq-extension.xml | grep "<name>" | sed -E "s|.*<name>(.*)</name>|\1|")
+            EXT_VERSION=$(cat ${TARGET_DIR}/hivemq-extension.xml | grep "<version>" | sed -E "s|.*<version>(.*)</version>|\1|")
+            LINE_COUNT=40 /opt/hivemq/bin/wait_log.sh "Extension \"${EXT_NAME}\" version ${EXT_VERSION} stopped successfully."
+        fi
+        echo "Extension stopped, deleting old version"
+        # Delete old version(s)
+        rm -f ${TARGET_DIR}/*.jar
+        # Ready to update, proceed as normal
+    fi
+    echo "Installing new extension version"
+    mkdir -p ${TARGET_DIR}
+fi
+
+# Disable if target state is false
+if [[ "${TARGET_STATE}" == "false" ]]; then
+    touch ${TARGET_DIR}/DISABLED
+    was_enabled=0
+else
+# Ensure it is enabled if target state is true
+    if [[ -f ${TARGET_DIR}/DISABLED ]]; then
+        rm -f ${TARGET_DIR}/DISABLED
+        was_enabled=0
+    fi
+fi
+
+if [[ ${EXTENSION_URI} != "preinstalled" ]]; then
+    cd ${install_dir}
+    # Move extension into target directory
+    cp -r */** ${TARGET_DIR}/
+    cd ${TARGET_DIR}
+    /opt/hivemq/bin/run_initialization.sh ${EXTENSION_NAME}
+
+    # Make sure the extension will enable, only if the state isn't DISABLED.
+    if [[ "${ASYNC_INSTALL}" != "true" ]]; then
+        if [[ "${TARGET_STATE}" == "true" ]]; then
+            rm -f ${TARGET_DIR}/DISABLED
+            TARGET_NAME=$(cat ${TARGET_DIR}/hivemq-extension.xml | grep "<name>" | sed -E "s|.*<name>(.*)</name>|\1|")
+            TARGET_VERSION=$(cat ${TARGET_DIR}/hivemq-extension.xml | grep "<version>" | sed -E "s|.*<version>(.*)</version>|\1|")
+            LINE_COUNT=20 /opt/hivemq/bin/wait_log.sh "Extension \"${TARGET_NAME}\" version ${TARGET_VERSION} started successfully."
+        fi
+    fi
+
+    # Cleanup
+    cd /
+    rm -rf ${install_dir}
+else
+    /opt/hivemq/bin/run_initialization.sh ${EXTENSION_NAME}
+fi

--- a/hivemq4/k8s-image/scripts/pre-entry_1.sh
+++ b/hivemq4/k8s-image/scripts/pre-entry_1.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+if [[ "${HIVEMQ_VERBOSE_ENTRYPOINT}" == "true" ]]; then
+  set -o xtrace
+fi
+
+# Kill child scripts (-> extension install) and exit self
+trap 'echo "Received SIGTERM during initialization, exiting..." && kill -9 ${PIDS} && exit 1' TERM
+
+PIDS=""
+
+echo "Copying external files"
+
+chmod -R 777 /hivemq-data/*
+cp -rsv /hivemq-data/* /opt/hivemq/
+
+cp -rsv /conf-override/* /opt/hivemq/
+
+# For config.xml from yaml
+if [[ -n ${HIVEMQ_CONFIG_OVERRIDE} ]]; then
+    echo "Rewriting config.xml..."
+    echo "${HIVEMQ_CONFIG_OVERRIDE}" > /opt/hivemq/conf/config.xml
+    HIVEMQ_LISTENER_CONFIGURATION="${HIVEMQ_LISTENER_CONFIGURATION//$'\n'/}"
+    sed -i "s|--LISTENER-CONFIGURATION--|${HIVEMQ_LISTENER_CONFIGURATION}|" /opt/hivemq/conf/config.xml
+
+    HIVEMQ_REST_API_CONFIGURATION="${HIVEMQ_REST_API_CONFIGURATION//$'\n'/}"
+    sed -i "s|<\!--REST-API-CONFIGURATION-->|${HIVEMQ_REST_API_CONFIGURATION}|" /opt/hivemq/conf/config.xml
+fi
+
+# For each file mounted from a configMap: Create an initial .lastUpdate file so we can reconcile if anything needs to be restarted due to a missed MODIFY notification
+echo "Creating initial lastUpdate files..."
+for file in $(find /conf-override -type f | grep -v /conf-override/data); do
+    cp -rv "${file}" "${file/\/conf-override//opt/hivemq}.lastUpdate"
+    chmod 777 "${file/\/conf-override//opt/hivemq}.lastUpdate"
+done
+for file in $(find /hivemq-data -type f); do
+    cp -rv "${file}" "${file/\/hivemq-data//opt/hivemq}.lastUpdate"
+    chmod 777 "${file/\/hivemq-data//opt/hivemq}.lastUpdate"
+done
+
+if [[ ${HIVEMQ_ENABLE_PROMETHEUS} != "true" ]]; then
+  echo "Disabling Prometheus"
+  # For standard docker interoperability
+  mkdir -p /opt/hivemq/extensions/hivemq-prometheus-extension/
+  touch /opt/hivemq/extensions/hivemq-prometheus-extension/DISABLED
+fi
+
+cp -s /etc/podinfo/replica-count /opt/hivemq/initial_node_count
+
+echo "Pod info:"
+cat /etc/podinfo/extension-state
+
+# Initialize extension state variables
+mapfile -d ' ' -t EXTENSION_NAMES < <(grep extension-names /etc/podinfo/extension-state | sed -E 's|^extension-names=(.*)|\1|' | tr -d '\n')
+mapfile -d ' ' -t EXTENSION_STATES < <(grep extension-states /etc/podinfo/extension-state | sed -E 's|^extension-states=(.*)|\1|' | tr -d '\n')
+mapfile -d ' ' -t EXTENSION_URIS < <(grep extension-uris /etc/podinfo/extension-state | sed -E 's|^extension-uris=(.*)|\1|' | tr -d '\n')
+
+if [[ ${#EXTENSION_NAMES[@]} -ge 1 ]]; then
+    for ((iter=0; iter<${#EXTENSION_NAMES[@]}; iter++)); do
+        echo "Installing extension #$iter with name: ${EXTENSION_NAMES[$iter]}, URI: ${EXTENSION_URIS[$iter]}, enabled state: ${EXTENSION_STATES[$iter]}"
+        ASYNC_INSTALL=true /opt/hivemq/bin/install_extension.sh "${EXTENSION_URIS[$iter]}" "${EXTENSION_NAMES[$iter]}" "${EXTENSION_STATES[$iter]}" &
+        PIDS="$PIDS $!"
+        wait $!
+    done
+fi
+
+/opt/hivemq/bin/set_log_level.sh
+
+# Link to the mapping properties file for auto file syncing
+cat /etc/podinfo/config-state
+cp -s /etc/podinfo/config-state /opt/hivemq/extensions/hivemq-k8s-sync-extension/mapping.properties

--- a/hivemq4/k8s-image/scripts/readiness_probe.sh
+++ b/hivemq4/k8s-image/scripts/readiness_probe.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# A pretty hacky readiness probe until we have a proper API in HiveMQ
+
+TARGET_SIZE=$(cat /opt/hivemq/initial_node_count)
+
+# Once we're ready we will always be for the remainder of the lifetime of the pod
+if [[ -f ready_file ]]; then
+  exit 0
+fi
+
+
+HAS_STARTED=$(tail -n1000 /opt/hivemq/log/hivemq.log | grep 'Started HiveMQ in' | tail -n1 | wc -l)
+if [[ "${TARGET_SIZE}" == 1 ]]; then
+  if (( HAS_STARTED == 1 )); then
+    touch ready_file
+    exit 0
+  fi
+fi
+
+CLUSTER_SIZE=$(tail -n1000 /opt/hivemq/log/hivemq.log | grep 'Cluster size' | sed -Ee 's/.*size = ([0-9]+).*/\1/' | tail -n1)
+
+# Log not found
+if [[ -z ${CLUSTER_SIZE} ]]; then
+  echo "Log statement not present (yet)"
+  exit 2
+fi
+
+if (( CLUSTER_SIZE >= TARGET_SIZE && HAS_STARTED == 1 )); then
+  touch ready_file
+  exit 0
+fi
+
+
+# Default fail
+echo "Cluster size not matched. Current: ${CLUSTER_SIZE}, expected: ${TARGET_SIZE}"
+exit 1

--- a/hivemq4/k8s-image/scripts/run_initialization.sh
+++ b/hivemq4/k8s-image/scripts/run_initialization.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+
+EXTENSION_NAME=${1}
+TARGET_DIR="/opt/hivemq/extensions/${EXTENSION_NAME}"
+cd ${TARGET_DIR}
+
+
+if [[ -f init_tmp ]]; then
+    echo "Using temporary init file"
+    chmod +x init_tmp
+    echo "Executing initialization script"
+    ./init_tmp
+    rm -f ./init_tmp
+else
+    if [[ -f "/etc/podinfo/init-extension-${EXTENSION_NAME}" ]]; then
+        echo "Using init script from config map"
+        # because config map is r/o
+        cat "/etc/podinfo/init-extension-${EXTENSION_NAME}" > ./init
+        echo "Executing initialization script"
+        chmod +x init
+        ./init
+    fi
+fi

--- a/hivemq4/k8s-image/scripts/set_log_level.sh
+++ b/hivemq4/k8s-image/scripts/set_log_level.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Set the root logger's level to the current dynamic state log level
+
+LOG_LEVEL=$(cat /etc/podinfo/log-level)
+
+if [[ ! -z $1 ]]; then
+    echo "Using user-provided log level $1"
+    LOG_LEVEL=$1
+fi
+
+sed -E -i -e "s|(.*)root level=\".*\"(.*)|\1root\ level=\"${LOG_LEVEL}\"\2|" /opt/hivemq/conf/logback.xml

--- a/hivemq4/k8s-image/scripts/wait_log.sh
+++ b/hivemq4/k8s-image/scripts/wait_log.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if [[ $# != 1 ]]; then
+    echo "Usage: $0 <log-statement>"
+    exit 1
+fi
+RECENT_LINE_COUNT=${LINE_COUNT:-2}
+COUNT=0
+LOG_STATEMENT=$1
+
+
+function line_matches_or_error() {
+    LAST_LINES=$(tail -n ${RECENT_LINE_COUNT} /opt/hivemq/log/hivemq.log)
+    MATCHING=false
+    if echo ${LAST_LINES} | grep -q -e "$1"; then
+        MATCHING=true
+    fi
+    if [[ ! -z ${ERROR_STATEMENT} ]]; then
+        if cat ${LAST_LINES} | grep -e "${ERROR_STATEMENT}"; then
+            MATCHING=true
+            echo -e "Error occurred"
+        fi
+    fi
+    if [[ ${MATCHING} == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+until line_matches_or_error "$1" || ((COUNT>29)); do
+    echo "Log statement '$1' not present... attempt $COUNT"
+    ((COUNT++))
+    sleep 2
+done
+
+if (( COUNT >= 30 )); then
+    echo "Statement $1 did not appear in time"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Move the k8s container out of the operator project into the containers project.

- Create the extension project 
- Update the Gradle build
- Update the Jenkins tasks

Repositories affected:

- https://github.com/hivemq/hivemq-k8s-sync-extension
- https://github.com/hivemq/hivemq
- https://github.com/hivemq/hivemq4-docker-images
- https://github.com/hivemq/hivemq-operator
