### PR TITLE
Update config.xml

### DIFF
--- a/hivemq4/k8s-image/config.xml
+++ b/hivemq4/k8s-image/config.xml
@@ -29,7 +29,7 @@
             </tcp>
         </transport>
         <discovery>
-            <extension/>
+                <reload-interval>${HIVEMQ_DNS_DISCOVERY_INTERVAL}</reload-interval>
         </discovery>
 
         <replication>


### PR DESCRIPTION
Please see issue #45 

line 33: cvc-type-3-1-2 XML-Syntax

Error message: Error cvc-type.3.1.2: Element 'ReqdExctnDt' is a simple type, so it must have no element information item [children].

How to fix: The reason for this error can be found out by examining the definition of ReqdExctnDt from the schema definition and fixing the value to be valid against the definition. In this example child element must be removed under the 'ReqdExctnDt':

see https://wiki.xmldation.com/Support/validator/cvc-type-3-1-2