### PR TITLE
Replace wget command with curl, as wget doesn't work properly with multi-arch images

### DIFF
--- a/hivemq4/k8s-image/Dockerfile
+++ b/hivemq4/k8s-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASEIMAGE=hivemq/hivemq4:dns-latest
 ARG PROMETHEUS_EXTENSION_VERSION=4.0.8
 
-FROM busybox:1.35.0 as BUILD
+FROM alpine:3.18 as BUILD
 ARG PROMETHEUS_EXTENSION_VERSION
 
 WORKDIR /opt/hivemq/extensions
@@ -10,7 +10,7 @@ COPY hivemq-k8s-sync-extension-*.zip ./hivemq-k8s-sync-extension.zip
 RUN unzip hivemq-k8s-sync-extension.zip -d /opt/hivemq/extensions/ \
     && rm hivemq-k8s-sync-extension.zip
 
-RUN wget https://github.com/hivemq/hivemq-prometheus-extension/releases/download/${PROMETHEUS_EXTENSION_VERSION}/hivemq-prometheus-extension-${PROMETHEUS_EXTENSION_VERSION}.zip \
+RUN apk --update add curl && curl -sLO https://github.com/hivemq/hivemq-prometheus-extension/releases/download/${PROMETHEUS_EXTENSION_VERSION}/hivemq-prometheus-extension-${PROMETHEUS_EXTENSION_VERSION}.zip \
     && unzip hivemq-prometheus-extension-${PROMETHEUS_EXTENSION_VERSION}.zip -d /opt/hivemq/extensions/ \
     && rm hivemq-prometheus-extension-${PROMETHEUS_EXTENSION_VERSION}.zip /opt/hivemq/extensions/hivemq-prometheus-extension/prometheusConfiguration.properties
 COPY prometheusConfiguration.properties /opt/hivemq/extensions/hivemq-prometheus-extension/


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/16971/details/

When trying to build these images for different OS/Architectures than the one where the build command is executed (cross docker build), we faced a problem regarding the `k8s-image` build image, there is a step where it needs to download the prometheus extension by using `wget` command.
This command does not work properly when building the image for an architecture different than the one where the Docker build command is executed. This happened in a Linux/AMD64 machine where we tried to install an ARM64 image, and also the other way around when trying to build a Docker AMD64 image from a ARM64 machine.

```
wget: error getting response: Connection reset by peer
```

We are not sure whether this is a problem with the wget binary itself for different archictectures, or for the one with comes with the `busybox` image we use to build the image, or even related to the github URL to download this particular [Prometheus extension](https://github.com/hivemq/hivemq-prometheus-extension/releases/download/4.0.8/hivemq-prometheus-extension-4.0.8.zip).

So as a solution, we will replace the `wget` with the `curl` command by installing in the `alpine` Docker image that is an extension of the `busybox` one but with at least it comes with a package manager. It should not have any impact since this Docker image is only used in a build stage for the Docker build, so this image will be discard afterwards.