### PR TITLE
Update HiveMQ DNS Discovery Extension to 4.2.5

### DIFF
--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=hivemq/hivemq4:latest
 
 FROM ${BASEIMAGE}
 
-ARG DNS_DISCOVERY_EXTENSION_VERSION=4.2.4
+ARG DNS_DISCOVERY_EXTENSION_VERSION=4.2.5
 
 # Use default DNS resolution timeout as default discovery interval
 ENV HIVEMQ_DNS_DISCOVERY_INTERVAL 31


### PR DESCRIPTION
See https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/tag/4.2.5