### PR TITLE
Disable digest pinning for hivemq/hivemq4 Docker images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,5 +8,15 @@
         "renovate-playground"
     ],
     "useBaseBranchConfig": "merge",
-    "branchPrefix": "renovate/hivemq4-docker-images/"
+    "branchPrefix": "renovate/hivemq4-docker-images/",
+    "packageRules": [
+        // disable updates of the HiveMQ Platform Docker images, so the release job picks up the locally built images
+        // using the `latest` tag (without digest pinning)
+        {
+            "matchPackagePrefixes": [
+                "hivemq/hivemq4"
+            ],
+            "enabled": false
+        }
+    ]
 }


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/18521/details/

# Current configuration

With the current configuration Renovate wants to digest pin the `hivemq/hivemq4` Docker images (see #67).

With `renovate-playground` with the `master` configuration, the same change will be scheduled:
![image](https://github.com/hivemq/hivemq4-docker-images/assets/4196298/377cb42c-5722-4e27-9622-f320d57d7bce)

# Custom configuration

With this custom configuration, the `hivemq/hivemq4` images will be ignored:
![image](https://github.com/hivemq/hivemq4-docker-images/assets/4196298/f5b94e7a-cdaf-4dab-a4e9-4d22264f9f8c)
