### PR TITLE
[4.28] Update HiveMQ DNS Cluster Discovery and Prometheus extensions to latest versions

### DIFF
--- a/hivemq4/dns-image/Dockerfile
+++ b/hivemq4/dns-image/Dockerfile
@@ -4,7 +4,7 @@ ARG BASEIMAGE=hivemq/hivemq4:latest
 # Additional build image to unpack the zip files and change the permissions without retaining large layers just for those operations
 FROM alpine:3.21@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45 AS unpack
 
-ARG DNS_DISCOVERY_EXTENSION_VERSION=4.3.1
+ARG DNS_DISCOVERY_EXTENSION_VERSION=4.3.2
 
 RUN mkdir -p /opt/hivemq/extensions
 

--- a/hivemq4/k8s-image/Dockerfile
+++ b/hivemq4/k8s-image/Dockerfile
@@ -4,7 +4,7 @@ ARG BASEIMAGE=hivemq/hivemq4:dns-latest
 # Additional build image to unpack the zip files and change the permissions without retaining large layers just for those operations
 FROM alpine:3.21@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45 AS unpack
 
-ARG PROMETHEUS_EXTENSION_VERSION=4.0.11
+ARG PROMETHEUS_EXTENSION_VERSION=4.0.12
 
 RUN mkdir -p /opt/hivemq/extensions
 


### PR DESCRIPTION
See https://github.com/hivemq/hivemq-prometheus-extension/releases/tag/4.0.12
See https://github.com/hivemq/hivemq-dns-cluster-discovery-extension/releases/tag/4.3.2